### PR TITLE
fix array vs varray issue

### DIFF
--- a/src/RouterCLILookupCodegenBuilder.hack
+++ b/src/RouterCLILookupCodegenBuilder.hack
@@ -207,7 +207,7 @@ final class RouterCLILookupCodegenBuilder {
 
   private function getMainMethod(): CodegenMethod {
     return $this->cg->codegenMethod('main')
-      ->addParameter('KeyedContainer<arraykey, string> $argv')
+      ->addParameter('KeyedContainer<int, string> $argv')
       ->setReturnType('void')
       ->setBody(
         $this->cg->codegenHackBuilder()

--- a/src/RouterCLILookupCodegenBuilder.hack
+++ b/src/RouterCLILookupCodegenBuilder.hack
@@ -207,7 +207,7 @@ final class RouterCLILookupCodegenBuilder {
 
   private function getMainMethod(): CodegenMethod {
     return $this->cg->codegenMethod('main')
-      ->addParameter('array<string> $argv')
+      ->addParameter('KeyedContainer<arraykey, string> $argv')
       ->setReturnType('void')
       ->setBody(
         $this->cg->codegenHackBuilder()

--- a/tests/examples/codegen/lookup-path.php
+++ b/tests/examples/codegen/lookup-path.php
@@ -7,7 +7,7 @@
  * To re-generate this file run vendor/hhvm/hacktest/bin/hacktest
  *
  *
- * @partially-generated SignedSource<<76b19caaac8ac0bc5694e356b10165ac>>
+ * @partially-generated SignedSource<<584ccd4103e1cb5ddaa5cdc80ba52017>>
  */
 namespace Facebook\HackRouter\CodeGen\Tests\Generated;
 /* BEGIN MANUAL SECTION init */
@@ -67,7 +67,7 @@ final class MySiteRouterCLILookup {
     }
   }
 
-  public function main(KeyedContainer<arraykey, string> $argv): void {
+  public function main(KeyedContainer<int, string> $argv): void {
     $path = $argv[1] ?? null;
     if ($path === null) {
       \fprintf(\STDERR, "Usage: %s PATH\n", $argv[0]);

--- a/tests/examples/codegen/lookup-path.php
+++ b/tests/examples/codegen/lookup-path.php
@@ -7,7 +7,7 @@
  * To re-generate this file run vendor/hhvm/hacktest/bin/hacktest
  *
  *
- * @partially-generated SignedSource<<dcbaf7d5f4a45c2c3e92a2b822b556d2>>
+ * @partially-generated SignedSource<<76b19caaac8ac0bc5694e356b10165ac>>
  */
 namespace Facebook\HackRouter\CodeGen\Tests\Generated;
 /* BEGIN MANUAL SECTION init */
@@ -67,7 +67,7 @@ final class MySiteRouterCLILookup {
     }
   }
 
-  public function main(array<string> $argv): void {
+  public function main(KeyedContainer<arraykey, string> $argv): void {
     $path = $argv[1] ?? null;
     if ($path === null) {
       \fprintf(\STDERR, "Usage: %s PATH\n", $argv[0]);


### PR DESCRIPTION
`varray<string>` would be accurate, but I figured `KeyedContainer` is safer in case someone's using this with a `darray` somehow, or if we decide to migrate to `vec` eventually.

`KeyedContainer<arraykey, string>` is kind of ugly though :(