### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 tests/ export-ignore
 examples/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["hack", "router", "routing", "hhvm"],
     "homepage": "https://github.com/hhvm/hack-router-codegen",
     "require": {
-        "hhvm": "^4.102",
+        "hhvm": "^4.128",
         "facebook/hack-router": "^0.19",
         "facebook/hack-http-request-response-interfaces": "^0.2|^0.3",
         "facebook/hack-codegen": "^4.5.0",

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
     },
     "autoload-dev": {
       "classmap": [ "tests/" ]
+    },
+    "config": {
+      "allow-plugins": {
+        "hhvm/hhvm-autoload": true
+      }
     }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -5,5 +5,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/Codegen.hack
+++ b/src/Codegen.hack
@@ -244,10 +244,10 @@ final class Codegen {
     ))
       ->setDiscardChanges(Shapes::idx($this->config ?? shape(), 'discardChanges', false))
       ->setGeneratedFrom($this->getGeneratedFrom());
-    foreach ($config['trait']['requireExtends'] ?? varray[] as $what) {
+    foreach ($config['trait']['requireExtends'] ?? vec[] as $what) {
       $builder->traitRequireExtends($what);
     }
-    foreach ($config['trait']['requireImplements'] ?? varray[] as $what) {
+    foreach ($config['trait']['requireImplements'] ?? vec[] as $what) {
       $builder->traitRequireImplements($what);
     }
 

--- a/src/Codegen.hack
+++ b/src/Codegen.hack
@@ -38,8 +38,9 @@ final class Codegen {
       'type' => string,
       'getter' => string,
     ),
-    'output' =>
-      (function(classname<IncludeInUriMap>): ?self::TUriBuilderOutput),
+    'output' => (function(
+      classname<IncludeInUriMap>,
+    ): ?self::TUriBuilderOutput),
   );
 
   const type TRequestParametersOutput = shape(
@@ -64,8 +65,9 @@ final class Codegen {
       ?'requireExtends' => ImmSet<classname<mixed>>,
       ?'requireImplements' => ImmSet<classname<mixed>>,
     ),
-    'output' =>
-      (function(classname<IncludeInUriMap>): ?self::TRequestParametersOutput),
+    'output' => (function(
+      classname<IncludeInUriMap>,
+    ): ?self::TRequestParametersOutput),
   );
 
   const type TRouterCodegenConfig = shape(
@@ -101,8 +103,8 @@ final class Codegen {
 
   <<__Memoize>>
   private function getGeneratedFrom(): CodegenGeneratedFrom {
-    return $this->config['generatedFrom']
-      ?? $this->getHackCodegenFactory()->codegenGeneratedFromScript();
+    return $this->config['generatedFrom'] ??
+      $this->getHackCodegenFactory()->codegenGeneratedFromScript();
   }
 
   public function build(): void {
@@ -131,10 +133,9 @@ final class Codegen {
     BaseParser $parser,
     private self::TCodegenConfig $config,
   ) {
-    $this->controllerFacts = (new ControllerFacts(
-      $this->getControllerBase(),
-      new ClassFacts($parser),
-    ));
+    $this->controllerFacts = (
+      new ControllerFacts($this->getControllerBase(), new ClassFacts($parser))
+    );
   }
 
   private function buildRouter(): void {
@@ -145,11 +146,13 @@ final class Codegen {
 
     $uri_map = (new UriMapBuilder($this->controllerFacts))->getUriMap();
 
-    (new RouterCodegenBuilder(
-      $this->getHackCodegenConfig(),
-      $this->getControllerBase(),
-      $uri_map,
-    ))
+    (
+      new RouterCodegenBuilder(
+        $this->getHackCodegenConfig(),
+        $this->getControllerBase(),
+        $uri_map,
+      )
+    )
       ->setCreateAbstractClass($config['abstract'])
       ->setGeneratedFrom($this->getGeneratedFrom())
       ->setDiscardChanges($this->config['discardChanges'] ?? false)
@@ -180,21 +183,24 @@ final class Codegen {
       return;
     }
     $base = $config['baseClass'] ?? UriBuilderCodegen::class;
-    $param_builder = $config['parameterCodegenBuilder']
-      ?? new RequestParameterCodegenBuilder($this->getHackCodegenConfig());
+    $param_builder = $config['parameterCodegenBuilder'] ??
+      new RequestParameterCodegenBuilder($this->getHackCodegenConfig());
     $get_output = $config['output'];
-    $return_spec = $config['returnSpec'] ?? shape(
-      'getter' => 'getPath',
-      'type' => 'string',
-    );
+    $return_spec = $config['returnSpec'] ??
+      shape(
+        'getter' => 'getPath',
+        'type' => 'string',
+      );
 
-    $builder = (new UriBuilderCodegenBuilder(
-      $this->getHackCodegenConfig(),
-      $base,
-      $param_builder,
-      $return_spec['getter'],
-      $return_spec['type'],
-    ))
+    $builder = (
+      new UriBuilderCodegenBuilder(
+        $this->getHackCodegenConfig(),
+        $base,
+        $param_builder,
+        $return_spec['getter'],
+        $return_spec['type'],
+      )
+    )
       ->setGeneratedFrom($this->getGeneratedFrom())
       ->setDiscardChanges(
         Shapes::idx($this->config ?? shape(), 'discardChanges', false),
@@ -225,24 +231,27 @@ final class Codegen {
       return;
     }
     $base = $config['baseClass'] ?? RequestParametersCodegen::class;
-    $param_builder = $config['parameterCodegenBuilder']
-      ?? new RequestParameterCodegenBuilder($this->getHackCodegenConfig());
+    $param_builder = $config['parameterCodegenBuilder'] ??
+      new RequestParameterCodegenBuilder($this->getHackCodegenConfig());
     $get_output = $config['output'];
     $getParameters = $config['getParameters'] ??
       (classname<HasUriPattern> $class) ==> {
-        return $class::getUriPattern()->getParameters()->map(
-          $param ==> shape('spec' => $param, 'optional' => false),
-        );
+        return $class::getUriPattern()->getParameters()
+          ->map($param ==> shape('spec' => $param, 'optional' => false));
       };
 
-    $builder = (new RequestParametersCodegenBuilder(
-      $this->getHackCodegenConfig(),
-      $getParameters,
-      $config['trait']['getRawParametersCode'],
-      $base,
-      $param_builder,
-    ))
-      ->setDiscardChanges(Shapes::idx($this->config ?? shape(), 'discardChanges', false))
+    $builder = (
+      new RequestParametersCodegenBuilder(
+        $this->getHackCodegenConfig(),
+        $getParameters,
+        $config['trait']['getRawParametersCode'],
+        $base,
+        $param_builder,
+      )
+    )
+      ->setDiscardChanges(
+        Shapes::idx($this->config ?? shape(), 'discardChanges', false),
+      )
       ->setGeneratedFrom($this->getGeneratedFrom());
     foreach ($config['trait']['requireExtends'] ?? vec[] as $what) {
       $builder->traitRequireExtends($what);

--- a/tests/RouterCLILookupCodegenBuilderTest.hack
+++ b/tests/RouterCLILookupCodegenBuilderTest.hack
@@ -44,7 +44,7 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
     ));
 
     $exit_code = null;
-    $output = varray[];
+    $output = vec[];
     \exec(
       \vsprintf(
         '%s -d hhvm.jit=0 %s %s',
@@ -67,7 +67,7 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
     await $this->rebuildAsync();
 
     $exit_code = 0;
-    $output = varray[];
+    $output = vec[];
     \exec(
       \vsprintf(
         '%s -d hhvm.jit=0 %s /foo/bar',

--- a/tests/RouterCLILookupCodegenBuilderTest.hack
+++ b/tests/RouterCLILookupCodegenBuilderTest.hack
@@ -53,7 +53,7 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
             self::CODEGEN_PATH,
             $path,
           }
-        )->map($x ==> \escapeshellarg($x)),
+        )->map(\escapeshellarg<>),
       ),
       inout $output,
       inout $exit_code,
@@ -77,7 +77,7 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
             \PHP_BINARY,
             self::CODEGEN_PATH,
           }
-        )->map($x ==> \escapeshellarg($x)),
+        )->map(\escapeshellarg<>),
       ),
       inout $output,
       inout $exit_code,

--- a/tests/RouterCLILookupCodegenBuilderTest.hack
+++ b/tests/RouterCLILookupCodegenBuilderTest.hack
@@ -13,20 +13,19 @@ use type Facebook\HackRouter\CodeGen\Tests\Generated\MySiteRouter;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackRouter\CodeGen\Tests\{
   GetRequestExampleController,
-  MyEnum
+  MyEnum,
 };
 
 final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
   use TestTypechecksTestTrait;
 
   const string CODEGEN_PATH = __DIR__.'/examples/codegen/lookup-path.php';
-  const string CODEGEN_NS =
-    "Facebook\\HackRouter\\CodeGen\\Tests\\Generated";
+  const string CODEGEN_NS = "Facebook\\HackRouter\\CodeGen\\Tests\\Generated";
 
   protected async function rebuildAsync(): Awaitable<void> {
-    (new RouterCLILookupCodegenBuilder(
-      $this->getCodegenConfig(),
-    ))->renderToFile(
+    (
+      new RouterCLILookupCodegenBuilder($this->getCodegenConfig())
+    )->renderToFile(
       self::CODEGEN_PATH,
       self::CODEGEN_NS,
       MySiteRouter::class,
@@ -48,11 +47,13 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
     \exec(
       \vsprintf(
         '%s -d hhvm.jit=0 %s %s',
-        (ImmSet {
-          \PHP_BINARY,
-          self::CODEGEN_PATH,
-          $path,
-        })->map($x ==> \escapeshellarg($x)),
+        (
+          ImmSet {
+            \PHP_BINARY,
+            self::CODEGEN_PATH,
+            $path,
+          }
+        )->map($x ==> \escapeshellarg($x)),
       ),
       inout $output,
       inout $exit_code,
@@ -71,10 +72,12 @@ final class RouterCLILookupCodegenBuilderTest extends BaseCodegenTestCase {
     \exec(
       \vsprintf(
         '%s -d hhvm.jit=0 %s /foo/bar',
-        (ImmSet {
-          \PHP_BINARY,
-          self::CODEGEN_PATH,
-        })->map($x ==> \escapeshellarg($x)),
+        (
+          ImmSet {
+            \PHP_BINARY,
+            self::CODEGEN_PATH,
+          }
+        )->map($x ==> \escapeshellarg($x)),
       ),
       inout $output,
       inout $exit_code,

--- a/tests/RouterCodegenBuilderTest.hack
+++ b/tests/RouterCodegenBuilderTest.hack
@@ -13,12 +13,10 @@ use type Facebook\DefinitionFinder\FileParser;
 use function Facebook\FBExpect\expect;
 use type Facebook\HackRouter\CodeGen\Tests\{
   GetRequestExampleController,
-  MyEnum
+  MyEnum,
 };
 use type Facebook\HackRouter\CodeGen\Tests\Generated\MySiteRouter;
-use type Facebook\HackRouter\PrivateImpl\{ClassFacts,
-  ControllerFacts
-};
+use type Facebook\HackRouter\PrivateImpl\{ClassFacts, ControllerFacts};
 use namespace HH\Lib\Str;
 
 final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
@@ -26,8 +24,7 @@ final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
   use TestTypechecksTestTrait;
 
   const string CODEGEN_PATH = __DIR__.'/examples/codegen/MySiteRouter.php';
-  const string CODEGEN_NS =
-    "Facebook\\HackRouter\\CodeGen\\Tests\\Generated";
+  const string CODEGEN_NS = "Facebook\\HackRouter\\CodeGen\\Tests\\Generated";
 
   private async function getBuilderAsync(
   ): Awaitable<RouterCodegenBuilder<GetRequestExampleController>> {
@@ -84,7 +81,7 @@ final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
 
   public async function testOverriddenGeneratedFrom(): Awaitable<void> {
     $code = $this->renderToString(
-        (await $this->getBuilderAsync())->setGeneratedFrom(
+      (await $this->getBuilderAsync())->setGeneratedFrom(
         $this->getCodegenFactory()->codegenGeneratedFromClass(self::class),
       ),
     );
@@ -102,7 +99,7 @@ final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
 
   public async function testCanCreateAbstract(): Awaitable<void> {
     $code = $this->renderToString(
-        (await $this->getBuilderAsync())->setCreateAbstractClass(true),
+      (await $this->getBuilderAsync())->setCreateAbstractClass(true),
     );
     $parser = await FileParser::fromDataAsync($code);
     $class = $parser->getClass(MySiteRouter::class);
@@ -125,10 +122,8 @@ final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
      * top-level */
     require_once(self::CODEGEN_PATH);
     $router = new MySiteRouter();
-    list($controller, $params) = $router->routeMethodAndPath(
-      HttpMethod::GET,
-      '/foo/123/derp',
-    );
+    list($controller, $params) =
+      $router->routeMethodAndPath(HttpMethod::GET, '/foo/123/derp');
     expect($controller)->toBeSame(GetRequestExampleController::class);
     $params = new RequestParameters(
       GetRequestExampleController::getUriPattern()->getParameters(),

--- a/tests/RouterCodegenBuilderTest.hack
+++ b/tests/RouterCodegenBuilderTest.hack
@@ -132,7 +132,7 @@ final class RouterCodegenBuilderTest extends BaseCodegenTestCase {
     expect($controller)->toBeSame(GetRequestExampleController::class);
     $params = new RequestParameters(
       GetRequestExampleController::getUriPattern()->getParameters(),
-      varray[],
+      vec[],
       $params,
     );
     expect($params->getString('MyString'))->toBeSame('foo');

--- a/tests/TestTypechecksTestTrait.hack
+++ b/tests/TestTypechecksTestTrait.hack
@@ -19,11 +19,7 @@ trait TestTypechecksTestTrait {
     await $this->rebuildAsync();
     $exit_code = 0;
     $out_array = vec[];
-    \exec(
-      'hh_client',
-      inout $out_array,
-      inout $exit_code,
-    );
+    \exec('hh_client', inout $out_array, inout $exit_code);
     expect($exit_code)->toBeSame(0, 'Typechecker errors found');
   }
 }

--- a/tests/TestTypechecksTestTrait.hack
+++ b/tests/TestTypechecksTestTrait.hack
@@ -18,7 +18,7 @@ trait TestTypechecksTestTrait {
   final public async function testTypechecks(): Awaitable<void> {
     await $this->rebuildAsync();
     $exit_code = 0;
-    $out_array = varray[];
+    $out_array = vec[];
     \exec(
       'hh_client',
       inout $out_array,


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.